### PR TITLE
escape_and_echo is now used to correctly output the validator_key

### DIFF
--- a/windows-chef-client-msi-psonly-withservice-nointernet.erb
+++ b/windows-chef-client-msi-psonly-withservice-nointernet.erb
@@ -53,7 +53,7 @@
 
 @ECHO Populating Chef configuration...
 > <%= bootstrap_directory %>\validation.pem (
- <%= validation_key %>
+ <%= escape_and_echo(validation_key) %>
 )
 
 <% if @config[:encrypted_data_bag_secret] -%>

--- a/windows-chef-client-msi-psonly-withservice.erb
+++ b/windows-chef-client-msi-psonly-withservice.erb
@@ -105,7 +105,7 @@
 
 @ECHO Populating Chef configuration...
 > <%= bootstrap_directory %>\validation.pem (
- <%= validation_key %>
+ <%= escape_and_echo(validation_key) %>
 )
 
 <% if @config[:encrypted_data_bag_secret] -%>


### PR DESCRIPTION
I had an issue where the validator_key was not being outputted to a file. This fixes that issue.
